### PR TITLE
Support kernel 5.12-rc4 and higher.

### DIFF
--- a/srandom.c
+++ b/srandom.c
@@ -16,7 +16,7 @@
 #define arr_RND_SIZE 67             /* Size of Array.  Must be >= 64. (actual size used will be 64, anything greater is thrown away). Recommended prime.*/
 #define num_arr_RND  16             /* Number of 512b Array (Must be power of 2) */
 #define sDEVICE_NAME "srandom"      /* Dev name as it appears in /proc/devices */
-#define AppVERSION "1.38.0"
+#define AppVERSION "1.39.0"
 #define THREAD_SLEEP_VALUE 7        /* Amount of time worker thread should sleep between each operation. Recommended prime */
 #define PAID 0
 // #define DEBUG 0
@@ -676,4 +676,3 @@ module_exit(mod_exit);
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR(DRIVER_AUTHOR);
 MODULE_DESCRIPTION(DRIVER_DESC);
-MODULE_SUPPORTED_DEVICE("/dev/srandom");


### PR DESCRIPTION
In kernel 5.12-rc4, the macro `MODULE_SUPPORTED_DEVICE` was removed entirely as it never did anything, see commit 6417f03132a6952cd17ddd8eaddbac92b61b17e0 on [kernel.org](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=6417f03132a6952cd17ddd8eaddbac92b61b17e0) or [github.com](https://github.com/torvalds/linux/commit/6417f03132a6952cd17ddd8eaddbac92b61b17e0)

Therefore, srandom did not compile on these kernels. Simply removing `MODULE_SUPPORTED_DEVICE("/dev/srandom")` fixed the problem and remains compatible with older kernel versions as they simply ignored that line.