### PR TITLE
srandom.c: change "mykthread" to "srandom-kthread"

### DIFF
--- a/srandom.c
+++ b/srandom.c
@@ -238,7 +238,7 @@ int mod_init(void)
         }
 
         #if ! ULTRA_HIGH_SPEED_MODE
-                kthread = kthread_create(work_thread, NULL, "mykthread");
+                kthread = kthread_create(work_thread, NULL, "srandom-kthread");
                 wake_up_process(kthread);
         #endif
 


### PR DESCRIPTION
Propose changing Thread ID string from "mykthread" to "srandom-kthread"; positively affects listing of srandom in tools like `htop`.